### PR TITLE
Wait before contacting locks, and wait longer by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-saucelabs-executor",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "test executor for magellan test to run over saucelabs cloud",
   "main": "index.js",
   "scripts": {

--- a/src/locks.js
+++ b/src/locks.js
@@ -83,7 +83,7 @@ export default class Locks {
         });
       };
 
-      return setTimeout(() => { poll(); }, this.options.locksPollingInterval);
+      return poll();
     } else {
       return callback();
     }

--- a/src/locks.js
+++ b/src/locks.js
@@ -83,7 +83,9 @@ export default class Locks {
         });
       };
 
-      return poll();
+      return setTimeout(() => {
+        poll();
+      }, this.options.locksPollingInterval);
     } else {
       return callback();
     }

--- a/src/locks.js
+++ b/src/locks.js
@@ -83,9 +83,7 @@ export default class Locks {
         });
       };
 
-      return setTimeout(() => {
-        poll();
-      }, this.options.locksPollingInterval);
+      return setTimeout(() => { poll(); }, this.options.locksPollingInterval);
     } else {
       return callback();
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -22,8 +22,8 @@ const config = {
 
   maxTunnels: 1,
   locksOutageTimeout: 1000 * 60 * 5,
-  locksPollingInterval: 2500,
-  locksRequestTimeout: 2500
+  locksPollingInterval: 5000,
+  locksRequestTimeout: 5000
 };
 
 

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -34,8 +34,8 @@ describe("Configuration", () => {
 
     expect(config.maxTunnels).to.equal(1);
     expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
-    expect(config.locksPollingInterval).to.equal(2500);
-    expect(config.locksRequestTimeout).to.equal(2500);
+    expect(config.locksPollingInterval).to.equal(5000);
+    expect(config.locksRequestTimeout).to.equal(5000);
   });
 
   describe("validateConfig", () => {
@@ -56,8 +56,8 @@ describe("Configuration", () => {
 
       expect(config.maxTunnels).to.equal(1);
       expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
-      expect(config.locksPollingInterval).to.equal(2500);
-      expect(config.locksRequestTimeout).to.equal(2500);
+      expect(config.locksPollingInterval).to.equal(5000);
+      expect(config.locksRequestTimeout).to.equal(5000);
     });
 
     describe("executor enabled", () => {
@@ -95,8 +95,8 @@ describe("Configuration", () => {
 
         expect(config.maxTunnels).to.equal(1);
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
-        expect(config.locksPollingInterval).to.equal(2500);
-        expect(config.locksRequestTimeout).to.equal(2500);
+        expect(config.locksPollingInterval).to.equal(5000);
+        expect(config.locksRequestTimeout).to.equal(5000);
       });
 
       it("succeed with isEnabled", () => {
@@ -128,8 +128,8 @@ describe("Configuration", () => {
 
         expect(config.maxTunnels).to.equal(1);
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
-        expect(config.locksPollingInterval).to.equal(2500);
-        expect(config.locksRequestTimeout).to.equal(2500);
+        expect(config.locksPollingInterval).to.equal(5000);
+        expect(config.locksRequestTimeout).to.equal(5000);
       });
 
       it("missing SAUCE_USERNAME", () => {


### PR DESCRIPTION
This PR increases the default locks polling interval to `5000ms` and also waits before contacting locks for the first time.

/cc @archlichking 