### PR TITLE
add `--sauce_tunnel_config` to support customized flags via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,51 @@ Please follow the steps
 
 Congratulations, you're all set. 
 
+## Customize sauce tunnel flags
+
+`testarmada-magellan-saucelabs-executor` supports customized sauce tunnel flags since `1.0.3`. You can put customized flags into a `.json` file and use `--sauce_tunnel_config` to load the file. 
+
+```javascript
+tunnel config json example
+
+{
+  "fastFailRegexps": "p.typekit.net",
+  "directDomains": "google.com",
+  "noSslBumpDomains": "google.com"
+}
+```
+
+For all supported flags please refer to [here](https://github.com/bermi/sauce-connect-launcher#advanced-usage).
+
+### Loading rules for env variables and customized flags
+
+Some parameters can be passed in from both env variables and customized flags (such as `SAUCE_USERNAME` from env variables and `username` from flags). It is very important to understand which one will take effect if set up both.
+
+ 1. env variable always has top priority.
+ 2. customized flags only work when no corresponding env variable set
+
 ## Example
 To run test in latest chrome on Windows10 without a tunnel
-```
+```console
 $ ./node_modules/.bin/magellan --sauce_browser chrome_latest_Windows_10_Desktop --test xxx
 ```
 
 To run test in latest chrome on Windows10 with a new tunnel
-```
+```console
 $ ./node_modules/.bin/magellan --sauce_browser chrome_latest_Windows_10_Desktop --sauce_create_tunnels --test xxx
 ```
 
 To run test in latest chrome on Windows10 with an exiting tunnel
-```
+```console
 $ ./node_modules/.bin/magellan --sauce_browser chrome_latest_Windows_10_Desktop --sauce_tunnel_id xxx --test xxx
 ```
 
 To run test in latest chrome, latest firefox on Windows10 and safari 9 on MacOS 10.11
-```
+```console
 $ ./node_modules/.bin/magellan --sauce_browsers chrome_latest_Windows_10_Desktop,firefox_latest_Windows_10_Desktop,safari_9_OS_X_10_11_Desktop --test xxx
+```
+
+To create sauce tunnel connection with customized flags from `./tunnel.json`
+```console
+$ ./node_modules/.bin/magellan --sauce_browsers chrome_latest_Windows_10_Desktop --sauce_create_tunnels --sauce_tunnel_config ./tunnel.json 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-saucelabs-executor",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "test executor for magellan test to run over saucelabs cloud",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-saucelabs-executor",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "test executor for magellan test to run over saucelabs cloud",
   "main": "index.js",
   "scripts": {

--- a/src/executor.js
+++ b/src/executor.js
@@ -43,7 +43,7 @@ export default {
         .then(() => {
           analytics.mark("sauce-open-tunnels");
           logger.log("Sauce tunnel is opened!  Continuing...");
-          logger.log(`Assigned tunnel [${config.sauceTunnelId}] to all workers`);
+          logger.log(`Assigned tunnel [${config.tunnel.tunnelIdentifier}] to all workers`);
         })
         .catch((err) => {
           analytics.mark("sauce-open-tunnels", "failed");

--- a/src/executor.js
+++ b/src/executor.js
@@ -53,8 +53,8 @@ export default {
         });
     } else {
       return new Promise((resolve) => {
-        if (config.sauceTunnelId) {
-          let tunnelAnnouncement = config.sauceTunnelId;
+        if (config.tunnel.tunnelIdentifier) {
+          let tunnelAnnouncement = config.tunnel.tunnelIdentifier;
           if (config.sharedSauceParentAccount) {
             tunnelAnnouncement = `${config.sharedSauceParentAccount}/${tunnelAnnouncement}`;
           }

--- a/src/help.js
+++ b/src/help.js
@@ -33,5 +33,11 @@ export default {
     "example": "testsauceaccount",
     "description": "Specify parent account name if existing shared secure tunnel is "
     + " in use (exclusive with --sauce_create_tunnels)"
+  },
+  "sauce_tunnel_config": {
+    "visible": true,
+    "type": "string",
+    "example": "tunnelConfig.json",
+    "description": "Specify a configuration file to read from to create sauce tunnel"
   }
 };

--- a/src/profile.js
+++ b/src/profile.js
@@ -21,8 +21,8 @@ export default {
   getNightwatchConfig: (profile, sauceSettings) => {
     const capabilities = _.assign({}, profile.desiredCapabilities);
 
-    if (sauceSettings.sauceTunnelId) {
-      capabilities["tunnel-identifier"] = sauceSettings.sauceTunnelId;
+    if (sauceSettings.tunnel.tunnelIdentifier) {
+      capabilities["tunnel-identifier"] = sauceSettings.tunnel.tunnelIdentifier;
       if (sauceSettings.sharedSauceParentAccount) {
         // if tunnel is shared by parent account
         capabilities["parent-tunnel"] = sauceSettings.sharedSauceParentAccount;
@@ -35,8 +35,8 @@ export default {
     /*eslint-disable camelcase*/
     const config = {
       desiredCapabilities: capabilities,
-      username: sauceSettings.username,
-      access_key: sauceSettings.accessKey
+      username: sauceSettings.tunnel.username,
+      access_key: sauceSettings.tunnel.accessKey
     };
 
     logger.debug(`executor config: ${JSON.stringify(config)}`);

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,21 +6,20 @@ const TEMP_DIR = path.resolve(argvs.temp_dir || "./temp");
 
 /*eslint-disable no-magic-numbers*/
 const config = {
-  // required:
-  username: null,
-  accessKey: null,
-  sauceConnectVersion: null,
+  tunnel: {
+    // required:
+    username: null,
+    accessKey: null,
+    connectVersion: null,
 
-  // optional:
-  sauceTunnelId: null,
+    // optional:
+    tunnelIdentifier: null,
+    fastFailRegexps: null
+  },
   sharedSauceParentAccount: null,
-  tunnelTimeout: null,
-  useTunnels: null,
-  fastFailRegexps: null,
+  useTunnels: false,
 
   locksServerLocation: null,
-
-  maxTunnels: 1,
   locksOutageTimeout: 1000 * 60 * 5,
   locksPollingInterval: 5000,
   locksRequestTimeout: 5000

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -113,7 +113,7 @@ export default class Tunnel {
   close() {
     return new Promise((resolve) => {
       if (this.tunnelInfo) {
-        logger.log(`Closing sauce tunnel [${this.options.sauceTunnelId}]`);
+        logger.log(`Closing sauce tunnel [${this.options.tunnel.tunnelIdentifier}]`);
         this.tunnelInfo.process.close(() => {
           resolve();
         });

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -17,19 +17,19 @@ export default class Tunnel {
 
   initialize() {
     return new Promise((resolve, reject) => {
-      if (!this.options.username) {
+      if (!this.options.tunnel.username) {
         return reject("Sauce tunnel support is missing configuration: Sauce username.");
       }
 
-      if (!this.options.accessKey) {
+      if (!this.options.tunnel.accessKey) {
         return reject("Sauce tunnel support is missing configuration: Sauce access key.");
       }
 
       analytics.push("sauce-connect-launcher-download");
+
+      const options = _.assign({}, this.options.tunnel, { logger: logger.debug });
       /*eslint-disable no-console */
-      return this.sauceConnectLauncher.download({
-        logger: console.log.bind(console)
-      }, (err) => {
+      return this.sauceConnectLauncher.download(options, (err) => {
         if (err) {
           analytics.mark("sauce-connect-launcher-download", "failed");
           logger.err("Failed to download sauce connect binary:");
@@ -48,33 +48,25 @@ export default class Tunnel {
 
   open() {
     this.tunnelInfo = null;
-    const tunnelId = this.options.sauceTunnelId;
-    const username = this.options.username;
-    const accessKey = this.options.accessKey;
     let connectFailures = 0;
 
-    logger.log(`Opening sauce tunnel [${ tunnelId }] for user ${ username}`);
+    logger.log(`Opening sauce tunnel [${this.options.tunnel.tunnelIdentifier}]`
+      + ` for user ${this.options.tunnel.username}`);
 
     const connect = (/*runDiagnostics*/) => {
       return new Promise((resolve, reject) => {
-        const logFilePath = `${path.resolve(settings.tempDir) }/build-${
-           settings.buildId }_sauceconnect_${ tunnelId }.log`;
-        const sauceOptions = {
-          username,
-          accessKey,
-          tunnelIdentifier: tunnelId,
-          readyFileId: tunnelId,
+        const logFilePath = `${path.resolve(settings.tempDir)}/build-${
+          settings.buildId}_sauceconnect_${this.options.tunnel.tunnelIdentifier}.log`;
+
+        const sauceOptions = _.assign({}, this.options.tunnel, {
+          readyFileId: this.options.tunnel.tunnelIdentifier,
           verbose: settings.debug,
           verboseDebugging: settings.debug,
           logfile: logFilePath,
           port: settings.BASE_SELENIUM_PORT_OFFSET
-        };
+        });
 
-        if (this.options.fastFailRegexps) {
-          sauceOptions.fastFailRegexps = this.options.fastFailRegexpss;
-        }
-
-        logger.debug(`calling sauceConnectLauncher() w/ ${ JSON.stringify(sauceOptions)}`);
+        logger.debug(`calling sauceConnectLauncher() w/ ${JSON.stringify(sauceOptions)}`);
 
         this.sauceConnectLauncher(sauceOptions, (err, sauceConnectProcess) => {
           if (err) {
@@ -96,11 +88,11 @@ export default class Tunnel {
                 // Make sure other attempts don't try to re-state this error.
                 settings.BAILED = true;
                 return reject(new Error(`Failed to create a secure sauce tunnel after ${
-                   connectFailures } attempts.`));
+                  connectFailures} attempts.`));
               } else {
                 // Otherwise, keep retrying, and hope this is merely a blip and not an outage.
                 logger.err(`>>> Sauce Tunnel Connection Failed!  Retrying ${
-                   connectFailures } of ${ settings.MAX_CONNECT_RETRIES } attempts...`);
+                  connectFailures} of ${settings.MAX_CONNECT_RETRIES} attempts...`);
 
                 return connect()
                   .then(resolve)
@@ -121,7 +113,7 @@ export default class Tunnel {
   close() {
     return new Promise((resolve) => {
       if (this.tunnelInfo) {
-        logger.log(`Closing sauce tunnel [${ this.options.sauceTunnelId }]`);
+        logger.log(`Closing sauce tunnel [${this.options.sauceTunnelId}]`);
         this.tunnelInfo.process.close(() => {
           resolve();
         });

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -22,17 +22,16 @@ describe("Configuration", () => {
   it("getConfig", () => {
     const config = configuration.getConfig();
 
-    expect(config.username).to.equal(null);
-    expect(config.accessKey).to.equal(null);
-    expect(config.sauceConnectVersion).to.equal(null);
-    expect(config.sauceTunnelId).to.equal(null);
-    expect(config.sharedSauceParentAccount).to.equal(null);
-    expect(config.tunnelTimeout).to.equal(null);
-    expect(config.useTunnels).to.equal(null);
-    expect(config.fastFailRegexps).to.equal(null);
-    expect(config.locksServerLocation).to.equal(null);
+    expect(config.tunnel.username).to.equal(null);
+    expect(config.tunnel.accessKey).to.equal(null);
+    expect(config.tunnel.connectVersion).to.equal(null);
+    expect(config.tunnel.tunnelIdentifier).to.equal(null);
+    expect(config.tunnel.fastFailRegexps).to.equal(null);
 
-    expect(config.maxTunnels).to.equal(1);
+    expect(config.sharedSauceParentAccount).to.equal(null);
+    expect(config.useTunnels).to.equal(false);
+
+    expect(config.locksServerLocation).to.equal(null);
     expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
     expect(config.locksPollingInterval).to.equal(5000);
     expect(config.locksRequestTimeout).to.equal(5000);
@@ -41,20 +40,19 @@ describe("Configuration", () => {
   describe("validateConfig", () => {
     it("Executor disabled", () => {
       let argvMock = {};
+      let envMock = {};
+      const config = configuration.validateConfig({}, argvMock, envMock);
 
-      const config = configuration.validateConfig({}, {}, {});
+      expect(config.tunnel.username).to.equal(null);
+      expect(config.tunnel.accessKey).to.equal(null);
+      expect(config.tunnel.connectVersion).to.equal(null);
+      expect(config.tunnel.tunnelIdentifier).to.equal(null);
+      expect(config.tunnel.fastFailRegexps).to.equal(null);
 
-      expect(config.username).to.equal(undefined);
-      expect(config.accessKey).to.equal(undefined);
-      expect(config.sauceConnectVersion).to.equal(undefined);
-      expect(config.sauceTunnelId).to.equal(undefined);
-      expect(config.sharedSauceParentAccount).to.equal(undefined);
-      expect(config.tunnelTimeout).to.equal(undefined);
+      expect(config.sharedSauceParentAccount).to.equal(null);
       expect(config.useTunnels).to.equal(false);
-      expect(config.fastFailRegexps).to.equal(undefined);
-      expect(config.locksServerLocation).to.equal(undefined);
 
-      expect(config.maxTunnels).to.equal(1);
+      expect(config.locksServerLocation).to.equal(undefined);
       expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
       expect(config.locksPollingInterval).to.equal(5000);
       expect(config.locksRequestTimeout).to.equal(5000);
@@ -83,17 +81,16 @@ describe("Configuration", () => {
 
         const config = configuration.validateConfig({}, argvMock, envMock);
 
-        expect(config.username).to.equal("FAKE_USERNAME");
-        expect(config.accessKey).to.equal("FAKE_ACCESSKEY");
-        expect(config.sauceConnectVersion).to.equal("FAKE_VERSION");
-        expect(config.sauceTunnelId).to.be.a("string");
-        expect(config.sharedSauceParentAccount).to.equal(undefined);
-        expect(config.tunnelTimeout).to.equal(400);
-        expect(config.useTunnels).to.equal(true);
-        expect(config.fastFailRegexps).to.equal("a,b,c");
-        expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
+        expect(config.tunnel.username).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.accessKey).to.equal("FAKE_ACCESSKEY");
+        expect(config.tunnel.connectVersion).to.equal("FAKE_VERSION");
+        expect(config.tunnel.tunnelIdentifier).to.be.a("string");
+        expect(config.tunnel.fastFailRegexps).to.equal("a,b,c");
 
-        expect(config.maxTunnels).to.equal(1);
+        expect(config.sharedSauceParentAccount).to.equal(null);
+        expect(config.useTunnels).to.equal(true);
+
+        expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
         expect(config.locksPollingInterval).to.equal(5000);
         expect(config.locksRequestTimeout).to.equal(5000);
@@ -116,17 +113,16 @@ describe("Configuration", () => {
 
         const config = configuration.validateConfig({ isEnabled: true }, argvMock, envMock);
 
-        expect(config.username).to.equal("FAKE_USERNAME");
-        expect(config.accessKey).to.equal("FAKE_ACCESSKEY");
-        expect(config.sauceConnectVersion).to.equal("FAKE_VERSION");
-        expect(config.sauceTunnelId).to.be.a("string");
-        expect(config.sharedSauceParentAccount).to.equal(undefined);
-        expect(config.tunnelTimeout).to.equal(400);
-        expect(config.useTunnels).to.equal(true);
-        expect(config.fastFailRegexps).to.equal("a,b,c");
-        expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
+        expect(config.tunnel.username).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.accessKey).to.equal("FAKE_ACCESSKEY");
+        expect(config.tunnel.connectVersion).to.equal("FAKE_VERSION");
+        expect(config.tunnel.tunnelIdentifier).to.be.a("string");
+        expect(config.tunnel.fastFailRegexps).to.equal("a,b,c");
 
-        expect(config.maxTunnels).to.equal(1);
+        expect(config.sharedSauceParentAccount).to.equal(null);
+        expect(config.useTunnels).to.equal(true);
+
+        expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);
         expect(config.locksPollingInterval).to.equal(5000);
         expect(config.locksRequestTimeout).to.equal(5000);
@@ -139,8 +135,11 @@ describe("Configuration", () => {
           SAUCE_CONNECT_VERSION: "FAKE_VERSION"
         };
 
+
         try {
-          configuration.validateConfig({}, argvMock, envMock);
+          configuration.validateConfig({},
+            _.assign({}, argvMock, { sauce_tunnel_config: "./test/src/tunnel.json" }),
+            envMock);
           assert(false, "tunnel config shouldn't pass verification.");
         } catch (e) {
           expect(e.message).to.equal("Missing configuration for Saucelabs connection.");
@@ -155,7 +154,9 @@ describe("Configuration", () => {
         };
 
         try {
-          configuration.validateConfig({}, argvMock, envMock);
+          configuration.validateConfig({},
+            _.assign({}, argvMock, { sauce_tunnel_config: "./test/src/tunnel.json" }),
+            envMock);
           assert(false, "tunnel config shouldn't pass verification.");
         } catch (e) {
           expect(e.message).to.equal("Missing configuration for Saucelabs connection.");
@@ -170,7 +171,9 @@ describe("Configuration", () => {
         };
 
         try {
-          configuration.validateConfig({}, argvMock, envMock);
+          configuration.validateConfig({},
+            _.assign({}, argvMock, { sauce_tunnel_config: "./test/src/tunnel.json" }),
+            envMock);
         } catch (e) {
           assert(false, "tunnel config shouldn't fail verification.");
         }
@@ -215,6 +218,22 @@ describe("Configuration", () => {
           configuration.validateConfig({}, argvMock, envMock);
         } catch (e) {
           expect(e.message).to.match(/^--shared_sauce_parent_account only works with --sauce_tunnel_id/);
+        }
+      });
+
+      it("config file doesn't exist", () => {
+        let envMock = {
+          SAUCE_USERNAME: "FAKE_USERNAME",
+          SAUCE_ACCESS_KEY: "FAKE_ACCESSKEY",
+          SAUCE_CONNECT_VERSION: "FAKE_VERSION"
+        };
+
+        try {
+          configuration.validateConfig({},
+            _.assign({}, argvMock, { sauce_tunnel_config: "./test/src/nonetunnel.json" }),
+            envMock);
+        } catch (e) {
+          expect(e.message).to.match(/^Error: Cannot find module/);
         }
       });
     });

--- a/test/src/executor.test.js
+++ b/test/src/executor.test.js
@@ -58,7 +58,9 @@ describe("Executor", () => {
 
     it("no create tunnel", () => {
       mocks.config = {
-        useTunnels: null
+        tunnel: {
+          useTunnels: false
+        }
       };
 
       return executor
@@ -69,8 +71,10 @@ describe("Executor", () => {
 
     it("use existing tunnel", () => {
       mocks.config = {
-        useTunnels: null,
-        sauceTunnelId: "FAKE_ID",
+        tunnel: {
+          useTunnels: false,
+          tunnelIdentifier: "FAKE_ID",
+        },
         sharedSauceParentAccount: "FAKE_PARENT_ACCOUNT"
       };
 
@@ -82,7 +86,9 @@ describe("Executor", () => {
 
     it("create new tunnel", () => {
       mocks.config = {
-        useTunnels: true,
+        tunnel: {
+          useTunnels: true,
+        }
       };
 
       return executor
@@ -141,7 +147,7 @@ describe("Executor", () => {
           open() { return new Promise((resolve) => resolve()) }
         },
 
-        config: {}
+        config: { tunnel: {} }
       };
 
       return executor
@@ -191,7 +197,7 @@ describe("Executor", () => {
         open() { return new Promise((resolve) => resolve()) }
       },
 
-      config: {}
+      config: { tunnel: {} }
     };
 
     return executor
@@ -217,7 +223,7 @@ describe("Executor", () => {
         open() { return new Promise((resolve) => resolve()) }
       },
 
-      config: {}
+      config: { tunnel: {} }
     };
 
     return executor

--- a/test/src/executor.test.js
+++ b/test/src/executor.test.js
@@ -73,7 +73,9 @@ describe("Executor", () => {
       mocks.config = {
         tunnel: {
           useTunnels: false,
-          tunnelIdentifier: "FAKE_ID",
+          tunnel: {
+            tunnelIdentifier: "FAKE_ID"
+          }
         },
         sharedSauceParentAccount: "FAKE_PARENT_ACCOUNT"
       };
@@ -172,7 +174,10 @@ describe("Executor", () => {
         },
 
         config: {
-          useTunnels: true
+          useTunnels: true,
+          tunnel: {
+            tunnelIdentifier: null
+          }
         }
       };
 

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -6,13 +6,13 @@ import _ from "lodash";
 import logger from "../../lib/logger";
 
 // eat console logs
-logger.output = {
-  log() { },
-  error() { },
-  debug() { },
-  warn() { },
-  loghelp() { }
-};
+// logger.output = {
+//   log() { },
+//   error() { },
+//   debug() { },
+//   warn() { },
+//   loghelp() { }
+// };
 
 chai.use(chaiAsPromise);
 

--- a/test/src/tunnel.json
+++ b/test/src/tunnel.json
@@ -1,0 +1,7 @@
+{
+    "username": null,
+    "accessKey": null,
+    "connectVersion": null,
+    "tunnelIdentifier": null,
+    "fastFailRegexps": null
+}

--- a/test/src/tunnel.test.js
+++ b/test/src/tunnel.test.js
@@ -22,10 +22,12 @@ describe("Tunnel", () => {
   let tunnel;
 
   let options = {
-    username: "FAKE_USERNAME",
-    accessKey: "FAKE_ACCESSKEY",
-    sauceTunnelId: "FAKE_TUNNELID",
-    fastFailRegexps: "FAKE_EXP"
+    tunnel: {
+      username: "FAKE_USERNAME",
+      accessKey: "FAKE_ACCESSKEY",
+      tunnelIdentifier: "FAKE_TUNNELID",
+      fastFailRegexps: "FAKE_EXP"
+    }
   };
 
   let sauceConnectLauncherMock = {
@@ -39,10 +41,10 @@ describe("Tunnel", () => {
   });
 
   it("constructor", () => {
-    expect(tunnel.options.username).to.equal("FAKE_USERNAME");
-    expect(tunnel.options.accessKey).to.equal("FAKE_ACCESSKEY");
-    expect(tunnel.options.sauceTunnelId).to.equal("FAKE_TUNNELID");
-    expect(tunnel.options.fastFailRegexps).to.equal("FAKE_EXP");
+    expect(tunnel.options.tunnel.username).to.equal("FAKE_USERNAME");
+    expect(tunnel.options.tunnel.accessKey).to.equal("FAKE_ACCESSKEY");
+    expect(tunnel.options.tunnel.tunnelIdentifier).to.equal("FAKE_TUNNELID");
+    expect(tunnel.options.tunnel.fastFailRegexps).to.equal("FAKE_EXP");
   });
 
   describe("initialize", () => {
@@ -53,7 +55,7 @@ describe("Tunnel", () => {
     });
 
     it("missing username", () => {
-      tunnel = new Tunnel({}, sauceConnectLauncherMock);
+      tunnel = new Tunnel({ tunnel: {} }, sauceConnectLauncherMock);
 
       return tunnel
         .initialize()
@@ -65,7 +67,7 @@ describe("Tunnel", () => {
     });
 
     it("missing accesskey", () => {
-      tunnel = new Tunnel({ username: "FAKE_USERNAME" }, sauceConnectLauncherMock);
+      tunnel = new Tunnel({ tunnel: { username: "FAKE_USERNAME" } }, sauceConnectLauncherMock);
 
       return tunnel
         .initialize()


### PR DESCRIPTION
with this PR, sauce executor can read flags from config file, meanwhile previous env variables are still working.