### PR TITLE
attach logs to magellan main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-saucelabs-executor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "test executor for magellan test to run over saucelabs cloud",
   "main": "index.js",
   "scripts": {

--- a/src/logger.js
+++ b/src/logger.js
@@ -30,5 +30,17 @@ export default {
   },
   loghelp(msg) {
     this.output.log(msg);
+  },
+  stringifyLog(msg) {
+    const info = clc.greenBright("[INFO]");
+    return util.format("%s [%s] %s", info, PREFIX, msg);
+  },
+  stringifyWarn(msg) {
+    const warn = clc.yellowBright("[WARN]");
+    return util.format("%s [%s] %s", warn, PREFIX, msg);
+  },
+  stringifyErr(msg) {
+    const err = clc.redBright("[ERROR]");
+    return util.format("%s [%s] %s", err, PREFIX, msg);
   }
 };

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -20,6 +20,53 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 describe("Profile", () => {
+  describe("getNightwatchConfig", () => {
+    const p = {
+      desiredCapabilities: {
+        browser: "chrome"
+      }
+    };
+
+    const ss = {
+      tunnel: {
+        tunnelIdentifier: "FAKE_TUNNEL_ID",
+        username: "FAME_USERNAME",
+        accessKey: "FAKE_KEY"
+      }
+    };
+
+    it("only with tunnel id", () => {
+      const config = profile.getNightwatchConfig(p, ss);
+      expect(config.desiredCapabilities.browser).to.equal("chrome");
+      expect(config.desiredCapabilities["tunnel-identifier"]).to.equal("FAKE_TUNNEL_ID");
+      expect(config.desiredCapabilities["parent-tunnel"]).to.equal(undefined);
+      expect(config.username).to.equal("FAME_USERNAME");
+      expect(config.access_key).to.equal("FAKE_KEY");
+    });
+
+    it("with parent tunnel id", () => {
+      ss.sharedSauceParentAccount = "FAKE_SHARED";
+
+      const config = profile.getNightwatchConfig(p, ss);
+      expect(config.desiredCapabilities.browser).to.equal("chrome");
+      expect(config.desiredCapabilities["tunnel-identifier"]).to.equal("FAKE_TUNNEL_ID");
+      expect(config.desiredCapabilities["parent-tunnel"]).to.equal("FAKE_SHARED");
+      expect(config.username).to.equal("FAME_USERNAME");
+      expect(config.access_key).to.equal("FAKE_KEY");
+    });
+
+    it("no tunnel id", () => {
+      ss.tunnel.tunnelIdentifier = null;
+
+      const config = profile.getNightwatchConfig(p, ss);
+      expect(config.desiredCapabilities.browser).to.equal("chrome");
+      expect(config.desiredCapabilities["tunnel-identifier"]).to.equal(undefined);
+      expect(config.desiredCapabilities["parent-tunnel"]).to.equal(undefined);
+      expect(config.username).to.equal("FAME_USERNAME");
+      expect(config.access_key).to.equal("FAKE_KEY");
+    });
+  });
+
   describe("getProfiles", () => {
     it("with sauce_browser", () => {
       let argvMock = {


### PR DESCRIPTION
1. attach sauce replay url to magellan worker's output
2. ignore calling saucelabs api to report result if no sessionid is found