### PR TITLE
Proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Please follow the steps
 
 Congratulations, you're all set. 
 
+### Proxy Configuration
+
+To use a proxy to reach Saucelabs when querying the Saucelabs API, set an environment variable called `SAUCE_OUTBOUND_PROXY` before running Magellan with this executor:
+
+```console
+$ export SAUCE_OUTBOUND_PROXY=http://your-internal-proxy-host:8080
+```
+
 ## Customize sauce tunnel flags
 
 `testarmada-magellan-saucelabs-executor` supports customized sauce tunnel flags since `1.0.2`. You can put customized flags into a `.json` file and use `--sauce_tunnel_config` to load the file. 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "cli-color": "^1.1.0",
-    "guacamole": "^3.1.0",
+    "guacamole": "^3.2.1",
     "lodash": "^4.17.4",
     "request": "^2.79.0",
     "sauce-connect-launcher": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "cli-color": "^1.1.0",
-    "guacamole": "^2.0.2",
+    "guacamole": "^3.1.0",
     "lodash": "^4.17.4",
     "request": "^2.79.0",
     "sauce-connect-launcher": "^1.2.0",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -64,7 +64,8 @@ export default {
     // optional outbound HTTP Sauce-specific proxy configuration
     if (env.SAUCE_OUTBOUND_PROXY) {
       settings.config.proxy = {
-        httpProxy: env.SAUCE_OUTBOUND_PROXY
+        httpProxy: env.SAUCE_OUTBOUND_PROXY,
+        proxyType: "manual"
       };
     }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -62,9 +62,9 @@ export default {
     }
 
     // optional outbound HTTP Sauce-specific proxy configuration
-    if (env.SELENIUM_HTTP_PROXY) {
+    if (env.SAUCE_OUTBOUND_PROXY) {
       settings.config.proxy = {
-        httpProxy: env.SELENIUM_HTTP_PROXY
+        httpProxy: env.SAUCE_OUTBOUND_PROXY
       };
     }
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -61,6 +61,13 @@ export default {
       settings.config.tunnel.tunnelIdentifier = runArgv.sauce_tunnel_id;
     }
 
+    // optional outbound HTTP Sauce-specific proxy configuration
+    if (env.SELENIUM_HTTP_PROXY) {
+      settings.config.proxy = {
+        httpProxy: env.SELENIUM_HTTP_PROXY
+      };
+    }
+
     if (env.SAUCE_TUNNEL_FAST_FAIL_REGEXPS
       && !settings.config.tunnel.fastFailRegexps) {
       // only if fastFailRegexps isn't set anywhere

--- a/src/profile.js
+++ b/src/profile.js
@@ -3,6 +3,7 @@ import SauceBrowsers from "guacamole";
 import listSauceCliBrowsers from "guacamole/src/cli_list";
 import { argv } from "yargs";
 import logger from "./logger";
+import settings from "./settings";
 
 const FIREFOX_MARIONETTE = 48;
 
@@ -123,6 +124,11 @@ export default {
         return new Promise((resolve, reject) => {
           try {
             const desiredCapabilities = _patchFirefox(SauceBrowsers.get(prof)[0]);
+
+            if (settings.proxy) {
+              desiredCapabilities.proxy = settings.proxy;
+            }
+
             // add executor info back to capabilities
             const p = {
               desiredCapabilities,

--- a/src/profile.js
+++ b/src/profile.js
@@ -31,6 +31,10 @@ export default {
       delete capabilities["tunnel-identifier"];
     }
 
+    if (sauceSettings.proxy) {
+      capabilities.proxy = sauceSettings.proxy;
+    }
+
     /*eslint-disable camelcase*/
     const config = {
       desiredCapabilities: capabilities,

--- a/src/settings.js
+++ b/src/settings.js
@@ -16,6 +16,9 @@ const config = {
     tunnelIdentifier: null,
     fastFailRegexps: null
   },
+
+  proxy: null,
+
   sharedSauceParentAccount: null,
   useTunnels: false,
 

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -49,6 +49,8 @@ describe("Configuration", () => {
       expect(config.tunnel.tunnelIdentifier).to.equal(null);
       expect(config.tunnel.fastFailRegexps).to.equal(null);
 
+      expect(config.proxy).to.equal(null);
+
       expect(config.sharedSauceParentAccount).to.equal(null);
       expect(config.useTunnels).to.equal(false);
 
@@ -75,6 +77,7 @@ describe("Configuration", () => {
           SAUCE_ACCESS_KEY: "FAKE_ACCESSKEY",
           SAUCE_CONNECT_VERSION: "FAKE_VERSION",
           LOCKS_SERVER: "FAKE_LOCKSERVER/",
+          SAUCE_OUTBOUND_PROXY: "FAKE_PROXY",
           SAUCE_TUNNEL_CLOSE_TIMEOUT: 400,
           SAUCE_TUNNEL_FAST_FAIL_REGEXPS: "a,b,c"
         };
@@ -86,6 +89,8 @@ describe("Configuration", () => {
         expect(config.tunnel.connectVersion).to.equal("FAKE_VERSION");
         expect(config.tunnel.tunnelIdentifier).to.be.a("string");
         expect(config.tunnel.fastFailRegexps).to.equal("a,b,c");
+
+        expect(config.proxy.httpProxy).to.equal("FAKE_PROXY");
 
         expect(config.sharedSauceParentAccount).to.equal(null);
         expect(config.useTunnels).to.equal(true);

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -77,7 +77,7 @@ describe("Profile", () => {
         .getProfiles({}, argvMock)
         .then((profile) => {
           expect(profile.desiredCapabilities.browserName).to.equal("chrome");
-          expect(profile.desiredCapabilities.version).to.equal("57");
+          expect(profile.desiredCapabilities.version).to.equal("58");
           expect(profile.desiredCapabilities.platform).to.equal("Windows 10");
           expect(profile.executor).to.equal("sauce");
           expect(profile.nightwatchEnv).to.equal("sauce");
@@ -95,7 +95,7 @@ describe("Profile", () => {
         .then((profiles) => {
           expect(profiles.length).to.equal(2);
           expect(profiles[0].desiredCapabilities.browserName).to.equal("chrome");
-          expect(profiles[0].desiredCapabilities.version).to.equal("57");
+          expect(profiles[0].desiredCapabilities.version).to.equal("58");
           expect(profiles[0].desiredCapabilities.platform).to.equal("Windows 10");
           expect(profiles[0].executor).to.equal("sauce");
           expect(profiles[0].nightwatchEnv).to.equal("sauce");

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -32,6 +32,10 @@ describe("Profile", () => {
         tunnelIdentifier: "FAKE_TUNNEL_ID",
         username: "FAME_USERNAME",
         accessKey: "FAKE_KEY"
+      },
+
+      proxy: {
+        httpProxy: "FAKE_PROXY"
       }
     };
 
@@ -64,6 +68,11 @@ describe("Profile", () => {
       expect(config.desiredCapabilities["parent-tunnel"]).to.equal(undefined);
       expect(config.username).to.equal("FAME_USERNAME");
       expect(config.access_key).to.equal("FAKE_KEY");
+    });
+
+    it("sets proxy configuration", () => {
+      const config = profile.getNightwatchConfig(p, ss);
+      expect(config.desiredCapabilities.proxy.httpProxy).to.equal("FAKE_PROXY");
     });
   });
 

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -4,6 +4,7 @@ import chaiAsPromise from "chai-as-promised";
 import _ from "lodash";
 
 import logger from "../../lib/logger";
+import settings from "../../lib/settings";
 
 // eat console logs
 // logger.output = {
@@ -18,6 +19,8 @@ chai.use(chaiAsPromise);
 
 const expect = chai.expect;
 const assert = chai.assert;
+
+const originalProxy = settings.proxy;
 
 describe("Profile", () => {
   describe("getNightwatchConfig", () => {
@@ -130,6 +133,10 @@ describe("Profile", () => {
   });
 
   describe("getCapabilities", () => {
+    afterEach(() => {
+      settings.proxy = originalProxy;
+    });
+
     it("desktop web", () => {
       let p = {
         "browser": "microsoftedge_14_Windows_10_Desktop",
@@ -167,6 +174,24 @@ describe("Profile", () => {
           expect(result.executor).to.equal("sauce");
           expect(result.nightwatchEnv).to.equal("sauce");
           expect(result.id).to.equal("iphone_9_2_iOS_iPhone_Simulator");
+        });
+    });
+
+    it("uses a proxy", () => {
+      settings.proxy = {
+        httpProxy: "FAKE_PROXY"
+      };
+
+      let p = {
+        "browser": "microsoftedge_14_Windows_10_Desktop",
+        "resolution": "1280x1024",
+        "executor": "sauce"
+      };
+
+      return profile
+        .getCapabilities(p)
+        .then((result) => {
+          expect(result.desiredCapabilities.proxy.httpProxy).to.equal("FAKE_PROXY");
         });
     });
   });


### PR DESCRIPTION
This PR adds proxy support:
  - Option is configured by `SAUCE_OUTBOUND_PROXY` (same environment variable as `guacamole@3.2.1`
  - Updates to `guacamole@3.2.1` (which is the version of guacamole that has proxy support also)
  - Fixed unit tests that depend on unmocked Sauce API
  - Updated `README`

/cc @archlichking 