### PR TITLE
Proxy Support for Outbound Selenium Traffic (control messages) in Nightwatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Please follow the steps
 
 Congratulations, you're all set. 
 
+### Proxy Configuration
+
+To use a proxy to reach Saucelabs when querying the Saucelabs API, set an environment variable called `SAUCE_OUTBOUND_PROXY` before running Magellan with this executor:
+
+```console
+$ export SAUCE_OUTBOUND_PROXY=http://your-internal-proxy-host:8080
+```
+
 ## Customize sauce tunnel flags
 
 `testarmada-magellan-saucelabs-executor` supports customized sauce tunnel flags since `1.0.2`. You can put customized flags into a `.json` file and use `--sauce_tunnel_config` to load the file. 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "babel-eslint": "^7.1.1",
     "babel-preset-es2015": "^6.18.0",
     "cli-color": "^1.1.0",
-    "guacamole": "^2.0.2",
+    "guacamole": "^3.2.1",
     "lodash": "^4.17.4",
     "request": "^2.79.0",
     "sauce-connect-launcher": "^1.2.0",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -65,7 +65,7 @@ export default {
     // that this is for Selenium outbound control traffic only, not the
     // return path, and not to be confused with sauceconnect.
     if (env.SAUCE_OUTBOUND_PROXY) {
-      settings.config.seleniumOutboundProxy = env.SAUCE_OUTBOUND_PROXY;
+      settings.config.sauceOutboundProxy = env.SAUCE_OUTBOUND_PROXY;
     }
 
     if (env.SAUCE_TUNNEL_FAST_FAIL_REGEXPS

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -61,6 +61,13 @@ export default {
       settings.config.tunnel.tunnelIdentifier = runArgv.sauce_tunnel_id;
     }
 
+    // optional: *Outbound* HTTP Sauce-specific proxy configuration. Note
+    // that this is for Selenium outbound control traffic only, not the
+    // return path, and not to be confused with sauceconnect.
+    if (env.SAUCE_OUTBOUND_PROXY) {
+      settings.config.seleniumOutboundProxy = env.SAUCE_OUTBOUND_PROXY;
+    }
+
     if (env.SAUCE_TUNNEL_FAST_FAIL_REGEXPS
       && !settings.config.tunnel.fastFailRegexps) {
       // only if fastFailRegexps isn't set anywhere

--- a/src/profile.js
+++ b/src/profile.js
@@ -42,8 +42,8 @@ export default {
     // property directly on the environment configuration object (note: this is
     // NOT to be confused with proxy settings in desiredCapabilities, which are
     // used for return path traffic from the remote browser).
-    if (sauceSettings.seleniumOutboundProxy) {
-      config.proxy = sauceSettings.seleniumOutboundProxy;
+    if (sauceSettings.sauceOutboundProxy) {
+      config.proxy = sauceSettings.sauceOutboundProxy;
     }
 
     logger.debug(`executor config: ${JSON.stringify(config)}`);

--- a/src/profile.js
+++ b/src/profile.js
@@ -38,6 +38,14 @@ export default {
       access_key: sauceSettings.tunnel.accessKey
     };
 
+    // For *outbound Selenium control traffic*, Nightwatch supports a proxy
+    // property directly on the environment configuration object (note: this is
+    // NOT to be confused with proxy settings in desiredCapabilities, which are
+    // used for return path traffic from the remote browser).
+    if (sauceSettings.seleniumOutboundProxy) {
+      config.proxy = sauceSettings.seleniumOutboundProxy;
+    }
+
     logger.debug(`executor config: ${JSON.stringify(config)}`);
     return config;
   },

--- a/src/settings.js
+++ b/src/settings.js
@@ -19,7 +19,7 @@ const config = {
   sharedSauceParentAccount: null,
   useTunnels: false,
 
-  seleniumOutboundProxy: null,
+  sauceOutboundProxy: null,
 
   locksServerLocation: null,
   locksOutageTimeout: 1000 * 60 * 5,

--- a/src/settings.js
+++ b/src/settings.js
@@ -19,6 +19,8 @@ const config = {
   sharedSauceParentAccount: null,
   useTunnels: false,
 
+  seleniumOutboundProxy: null,
+
   locksServerLocation: null,
   locksOutageTimeout: 1000 * 60 * 5,
   locksPollingInterval: 5000,

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -76,7 +76,8 @@ describe("Configuration", () => {
           SAUCE_CONNECT_VERSION: "FAKE_VERSION",
           LOCKS_SERVER: "FAKE_LOCKSERVER/",
           SAUCE_TUNNEL_CLOSE_TIMEOUT: 400,
-          SAUCE_TUNNEL_FAST_FAIL_REGEXPS: "a,b,c"
+          SAUCE_TUNNEL_FAST_FAIL_REGEXPS: "a,b,c",
+          SAUCE_OUTBOUND_PROXY: "FAKE_PROXY"
         };
 
         const config = configuration.validateConfig({}, argvMock, envMock);
@@ -89,6 +90,7 @@ describe("Configuration", () => {
 
         expect(config.sharedSauceParentAccount).to.equal(null);
         expect(config.useTunnels).to.equal(true);
+        expect(config.seleniumOutboundProxy).to.equal("FAKE_PROXY");
 
         expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -90,7 +90,7 @@ describe("Configuration", () => {
 
         expect(config.sharedSauceParentAccount).to.equal(null);
         expect(config.useTunnels).to.equal(true);
-        expect(config.seleniumOutboundProxy).to.equal("FAKE_PROXY");
+        expect(config.sauceOutboundProxy).to.equal("FAKE_PROXY");
 
         expect(config.locksServerLocation).to.equal("FAKE_LOCKSERVER");
         expect(config.locksOutageTimeout).to.equal(1000 * 60 * 5);

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -21,19 +21,24 @@ const assert = chai.assert;
 
 describe("Profile", () => {
   describe("getNightwatchConfig", () => {
-    const p = {
-      desiredCapabilities: {
-        browser: "chrome"
-      }
-    };
+    let p = {};
+    let ss = {};
 
-    const ss = {
-      tunnel: {
-        tunnelIdentifier: "FAKE_TUNNEL_ID",
-        username: "FAME_USERNAME",
-        accessKey: "FAKE_KEY"
-      }
-    };
+    beforeEach(() => {
+      p = {
+        desiredCapabilities: {
+          browser: "chrome"
+        }
+      };
+
+      ss = {
+        tunnel: {
+          tunnelIdentifier: "FAKE_TUNNEL_ID",
+          username: "FAME_USERNAME",
+          accessKey: "FAKE_KEY"
+        }
+      };
+    });
 
     it("only with tunnel id", () => {
       const config = profile.getNightwatchConfig(p, ss);
@@ -65,6 +70,13 @@ describe("Profile", () => {
       expect(config.username).to.equal("FAME_USERNAME");
       expect(config.access_key).to.equal("FAKE_KEY");
     });
+
+    it("set proxy configuration", () => {
+      ss.seleniumOutboundProxy = "FAKE_PROXY";
+      const config = profile.getNightwatchConfig(p, ss);
+      expect(config.proxy).to.equal("FAKE_PROXY");
+    });
+
   });
 
   describe("getProfiles", () => {
@@ -77,7 +89,7 @@ describe("Profile", () => {
         .getProfiles({}, argvMock)
         .then((profile) => {
           expect(profile.desiredCapabilities.browserName).to.equal("chrome");
-          expect(profile.desiredCapabilities.version).to.equal("57");
+          expect(profile.desiredCapabilities.version).to.equal("58");
           expect(profile.desiredCapabilities.platform).to.equal("Windows 10");
           expect(profile.executor).to.equal("sauce");
           expect(profile.nightwatchEnv).to.equal("sauce");
@@ -95,7 +107,7 @@ describe("Profile", () => {
         .then((profiles) => {
           expect(profiles.length).to.equal(2);
           expect(profiles[0].desiredCapabilities.browserName).to.equal("chrome");
-          expect(profiles[0].desiredCapabilities.version).to.equal("57");
+          expect(profiles[0].desiredCapabilities.version).to.equal("58");
           expect(profiles[0].desiredCapabilities.platform).to.equal("Windows 10");
           expect(profiles[0].executor).to.equal("sauce");
           expect(profiles[0].nightwatchEnv).to.equal("sauce");

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -72,7 +72,7 @@ describe("Profile", () => {
     });
 
     it("set proxy configuration", () => {
-      ss.seleniumOutboundProxy = "FAKE_PROXY";
+      ss.sauceOutboundProxy = "FAKE_PROXY";
       const config = profile.getNightwatchConfig(p, ss);
       expect(config.proxy).to.equal("FAKE_PROXY");
     });


### PR DESCRIPTION
For **nightwatch** consumers of `magellan-saucelabs-executor`, this PR adds support for `SAUCE_OUTBOUND_PROXY`, which is the same variable used by `guacamole@3.2.1`

Also:

- Updates to `guacamole@3.2.1`
- Fixes regressed tests
- Adds tests for proxy configuration
- Updates `README`

Note: Support for non-nightwatch frameworks is not covered by this PR because other frameworks only extract `desiredCapabilities` at this time.

/cc @archlichking 