### PR TITLE
Support outbound proxy for saucelabs session update PUT req

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cli-color": "^1.1.0",
     "guacamole": "^3.2.1",
     "lodash": "^4.17.4",
-    "request": "^2.79.0",
+    "request": "^2.81.0",
     "sauce-connect-launcher": "^1.2.0",
     "yargs": "^6.6.0"
   },


### PR DESCRIPTION
This PR performs two updates:

  - Switches from `https` to `request` for the saucelabs session update PUT request at the end of a test (to allow for easy proxy support).
  - Adds proxy support in the above request if `SAUCELABS_OUTBOUND_PROXY` is set (see existing `README`).

/cc @archlichking 