### PR TITLE
allows to read more appium capabilities from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Please follow the following steps:
    --sauce_list_browsers                List the available browsers configured (Guacamole integrated).
    --sauce_create_tunnels               undefined
    --sauce_tunnel_id=testtunnel123123   Use an existing secure tunnel (exclusive with --sauce_create_tunnels)
+   --sauce_app=sauce-storage:your_app.apSpecify the app name in sauce temporary storage
+   --sauce_app_capabilities_config=sauceSpecify a configuration file containing customized appium desiredCapabilities for saucelabs VM
    --shared_sauce_parent_account=testsauSpecify parent account name if existing shared secure tunnel is  in use (exclusive with --sauce_create_tunnels)
  ```
 
@@ -92,12 +94,34 @@ tunnel config json example
 
 For all supported flags please refer to [here](https://github.com/bermi/sauce-connect-launcher#advanced-usage).
 
+## Customize appium desiredCapabilities (for app and mobile web test only)
+
+`testarmada-magellan-saucelabs-executor` supports customized appium desiredCapabilities in `.json` file via `--sauce_app_capabilities_config`. Any content in the `.json` file will be merged into desiredCapabilities directly.
+
+```javascript
+customized appium desiredCapabilities file
+
+{
+  "appiumVersion": "1.6.5",
+  "automationName": "XCUITest",
+  "sendKeyStrategy": "setValue"
+}
+```
+
 ### Loading rules for env variables and customized flags
 
 Some parameters can be passed in from both env variables and customized flags (such as `SAUCE_USERNAME` from env variables and `username` from flags). It is very important to understand which one will take effect if set up both.
 
  1. env variable always has top priority.
  2. customized flags only work when no corresponding env variable set
+
+### Loading rules for command line args, profile and configuration file content
+
+Some arguments can be passed in to excutor from both command line args, profile and configuration files, for example the temporary app location on saucelabs. The rule for deciding the final value of such argument is ordered as following
+
+ 1. configuration file content
+ 2. profile
+ 3. command line args (except `--sauce_app`, command line value of `--sauce_app` has the top priority)
 
 ## Example
 To run test in latest chrome on Windows10 without a tunnel

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-saucelabs-executor",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "test executor for magellan test to run over saucelabs cloud",
   "main": "index.js",
   "scripts": {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -10,12 +10,12 @@ const _loadConfig = (filename) => {
   try {
     /*eslint-disable global-require*/
     const config = require(filepath);
-    logger.log(`Loaded tunnel config file ${filename}`);
-    logger.debug(`Tunnel config from ${filename}:`);
+    logger.log(`Loaded config file ${filename}`);
+    logger.debug(`Loading config from ${filename}:`);
     logger.debug(`${JSON.stringify(config)}`);
     return _.cloneDeep(config);
   } catch (err) {
-    logger.err(`Cannot load tunnel config file from ${filename}`);
+    logger.err(`Cannot load config file from ${filename}`);
     logger.err(err);
     throw new Error(err);
   }
@@ -59,6 +59,16 @@ export default {
     // optional:
     if (runArgv.sauce_tunnel_id) {
       settings.config.tunnel.tunnelIdentifier = runArgv.sauce_tunnel_id;
+    }
+
+    // optional:
+    if (runArgv.sauce_app) {
+      settings.config.app = runArgv.sauce_app;
+    }
+
+    // optional:
+    if (runArgv.sauce_app_capabilities_config) {
+      settings.config.appCapabilitiesConfig = _loadConfig(runArgv.sauce_app_capabilities_config);
     }
 
     // optional: *Outbound* HTTP Sauce-specific proxy configuration. Note

--- a/src/help.js
+++ b/src/help.js
@@ -27,6 +27,19 @@ export default {
     "example": "testtunnel123123",
     "description": "Use an existing secure tunnel (exclusive with --sauce_create_tunnels)"
   },
+  "sauce_app": {
+    "visible": true,
+    "type": "string",
+    "example": "sauce-storage:your_app.apk",
+    "description": "Specify the app name in sauce temporary storage"
+  },
+  "sauce_app_capabilities_config": {
+    "visible": true,
+    "type": "string",
+    "example": "sauceAppCapabilitiesConfig.json",
+    "description": "Specify a configuration file containing customized appium "
+      + "desiredCapabilities for saucelabs VM"
+  },
   "shared_sauce_parent_account": {
     "visible": true,
     "type": "string",

--- a/src/locks.js
+++ b/src/locks.js
@@ -13,7 +13,7 @@ export default class Locks {
       this.api = this.apiMock || new LocksAPI(this.options);
 
       logger.log(`Using locks server at ${this.options.locksServerLocation
-      } for VM traffic control.`);
+        } for VM traffic control.`);
 
       return new Promise((resolve, reject) => {
         this.api.connect((err) => {
@@ -85,10 +85,16 @@ export default class Locks {
   }
 
   release(token) {
+    if (!this.api) {
+      return;
+    }
     this.api.release(token);
   }
 
   teardown() {
+    if (!this.api) {
+      return;
+    }
     this.api.close();
   }
 }

--- a/src/locks_socket_api.js
+++ b/src/locks_socket_api.js
@@ -84,7 +84,7 @@ export default class LocksAPI {
         // Reject unexpected or garbled messages
         const nextClaim = this.claims.shift();
         if (nextClaim) {
-          return nextClaim(new Error(`Received an unexpected message `
+          return nextClaim(new Error("Received an unexpected message "
             + `from locks server: ${message}`));
         }
 
@@ -111,7 +111,7 @@ export default class LocksAPI {
 
   claim(callback) {
     this.claims.push(callback);
-    this.socket.send(JSON.stringify({type: "claim"}));
+    this.socket.send(JSON.stringify({ type: "claim" }));
   }
 
   release(token) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -21,6 +21,9 @@ const config = {
 
   sauceOutboundProxy: null,
 
+  app: null,
+  appCapabilitiesConfig: null,
+
   locksServerLocation: null,
   locksOutageTimeout: 1000 * 60 * 5,
   locksPollingInterval: 5000,

--- a/test/config/appCapabilities.json
+++ b/test/config/appCapabilities.json
@@ -1,0 +1,7 @@
+{
+  "appiumVersion": "1.6.5",
+  "automationName": "xcuitest",
+  "sendKeyStrategy": "setValue",
+  "waitForAppScript": "true",
+  "platform": "OSX"
+}

--- a/test/src/locks.test.js
+++ b/test/src/locks.test.js
@@ -135,9 +135,12 @@ describe("Locks", () => {
   describe("release lock", () => {
     it("no lock server configured", () => {
       locks = new Locks({}, mockLocksAPI);
-      expect(() => {
+      
+      try{
         locks.release("FAKE_TOKEN");
-      }).to.throw(Error);
+      }catch(e){
+        assert(false, "shouldn't reach here");
+      }
     });
 
     it("lock server called", (done) => {


### PR DESCRIPTION
This PR allows user to defined more appium desiredCapabilities in config file. This PR also fixes the `locks` bug which errors out at the end of the test execution if no locks is configured