### PR TITLE
Update settings.js

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -2,7 +2,7 @@ import argvs from "yargs";
 import path from "path";
 
 const debug = argvs.argv.debug;
-const TEMP_DIR = path.resolve(argvs.temp_dir || "./temp");
+const TEMP_DIR = path.resolve(argvs.argv.temp_dir || "./temp");
 
 /*eslint-disable no-magic-numbers*/
 const config = {


### PR DESCRIPTION
fix: the `--temp_dir` argument wasn't being properly passed to Sauce Connect, so would always default to "./temp". Users that did not have a "./temp" directory at the root of their project (and had configured Magellan to point to an alternate path) would get a mysterious exit code 2 from Sauce Connect when it tried to create a log file at the non-existent path. This fixes that issue.